### PR TITLE
Fix console spam when downloading model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc

--- a/galai/__init__.py
+++ b/galai/__init__.py
@@ -31,13 +31,10 @@ def load_model(name: str, dtype: str=None, num_gpus: int=None):
             dtype = 'float32'
 
     if num_gpus is None:
-        num_gpus = 8
+        num_gpus = 1
 
     model = Model(name=name, dtype=dtype, num_gpus=num_gpus)
     model._set_tokenizer(tokenizer_path=get_tokenizer_path())
-    if name in ['mini', 'base']:
-        model._load_checkpoint(checkpoint_path=get_checkpoint_path(name))
-    else:
-        model._load_checkpoint(checkpoint_path=get_checkpoint_path(name))
+    model._load_checkpoint(checkpoint_path=get_checkpoint_path(name))
 
     return model

--- a/galai/model.py
+++ b/galai/model.py
@@ -1,6 +1,11 @@
 import os
 import torch
 
+# Use half GPU tensor as default to save on memory
+if torch.cuda.is_available():
+    torch.set_default_tensor_type('torch.cuda.BFloat16Tensor')
+
+
 from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 from parallelformers import parallelize
 from tokenizers import Tokenizer

--- a/galai/utils.py
+++ b/galai/utils.py
@@ -69,7 +69,7 @@ class DownloadProgressBar(tqdm.tqdm):
 
 def _download_file(file_url: str, file_loc: str):
     with DownloadProgressBar(unit='B', unit_scale=True,
-                             miniters=1, desc=file_url.split('/')[-1]) as t:
+                             mininterval=1, desc=file_url.split('/')[-1]) as t:
         urllib.request.urlretrieve(file_url, filename=file_loc, reporthook=t.update_to)
 
 def download_model(model_name: str, model_path: str):

--- a/galai/utils.py
+++ b/galai/utils.py
@@ -74,7 +74,7 @@ def _download_file(file_url: str, file_loc: str):
 
 def download_model(model_name: str, model_path: str):
 
-    for file_url in tqdm.tqdm(CHECKPOINT_PATHS[model_name]):
+    for file_url in tqdm.tqdm(CHECKPOINT_PATHS[model_name], mininterval=1):
         file_loc = os.path.join(model_path, file_url.split('/')[-1])
         if os.path.exists(file_loc):
             continue


### PR DESCRIPTION
Prevent fast console spam of progress when downloading the model. 
Set to 1 sec per message to prevent constant spam of download progress.