### PR TITLE
Removed "A demo is available at [link]"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     </a>
 </p>
 
-**GALACTICA** is a general-purpose scientific language model. It is trained on a large corpus of scientific text and data. It can perform scientific NLP tasks at a high level, as well as tasks such as citation prediction, mathematical reasoning, molecular property prediction and protein annotation. A demo is available at [galactica.org](https://galactica.org).
+**GALACTICA** is a general-purpose scientific language model. It is trained on a large corpus of scientific text and data. It can perform scientific NLP tasks at a high level, as well as tasks such as citation prediction, mathematical reasoning, molecular property prediction and protein annotation. More information is available at [galactica.org](https://galactica.org).
 
 ## Install
 


### PR DESCRIPTION
Demo was removed as of Nov. 17, per:
1) https://twitter.com/paperswithcode/status/1593259033787600896 
2) https://twitter.com/ylecun/status/1593293058174500865

Text now reads "More information is available at [link]"