### PR TITLE
add variable cache_dir to download models in specified directory 

### DIFF
--- a/galai/__init__.py
+++ b/galai/__init__.py
@@ -17,6 +17,7 @@ HF_MAPPING = {
 
 def load_model(
     name: str,
+    cache_dir: str,
     dtype: Union[str, torch.dtype] = None,
     num_gpus: int = None,
     parallelize: bool = False
@@ -128,6 +129,6 @@ def load_model(
         tensor_parallel=parallelize,
     )
     model._set_tokenizer(hf_model)
-    model._load_checkpoint(checkpoint_path=hf_model)
+    model._load_checkpoint(checkpoint_path=hf_model, cache_dir=cache_dir)
 
     return model

--- a/galai/model.py
+++ b/galai/model.py
@@ -82,7 +82,7 @@ class Model(object):
         self.max_input_length = 2020
         self._master_port = None
 
-    def _load_checkpoint(self, checkpoint_path: str):
+    def _load_checkpoint(self, checkpoint_path: str, cache_dir: str):
         """
         Loads the checkpoint for the model
 
@@ -108,6 +108,7 @@ class Model(object):
 
         self.model = OPTForCausalLM.from_pretrained(
             checkpoint_path,
+            cache_dir=cache_dir,
             torch_dtype=self.dtype,
             low_cpu_mem_usage=True,
             device_map=device_map,


### PR DESCRIPTION
Dear community, 
This feature would allow users to specify a particular directory on their computer where they want the galai to download and store machine learning models. This feature could be useful for users who want to keep their downloaded models organized in a particular location, such as a separate folder for each type of model, or for users who want to save disk space on their primary drive by storing the models on a secondary drive.

Kashfutdinov Bulat