### PR TITLE
Update to an accelerate min version that work (with google colab)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 torch>=1.12
+accelerate<=0.15.0· PyPI
+PyPI
+https://pypi.org › project › transformers
+Transformers provi
 transformers==4.25.1
 tokenizers
 parallelformers==1.2.7
-accelerate
 markdown>=3.4
 bleach[css]~=5.0.1
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 torch>=1.12
 accelerate<=0.15.0
-Transformers provi
 transformers==4.25.1
 tokenizers
 parallelformers==1.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 torch>=1.12
-accelerate<=0.15.0· PyPI
-PyPI
-https://pypi.org › project › transformers
+accelerate<=0.15.0
 Transformers provi
 transformers==4.25.1
 tokenizers


### PR DESCRIPTION
Fix for #73  -- might not be worth updating if I'm the only one experiencing this.

The missing function (`init_empty_weights`) exists in `accelerate 0.15.0` but I assume there's some downstream issue with how the 0.16.0 version and the transformers version you use interface.